### PR TITLE
Optimize slice creation in buildStructIndex to avoid double allocation

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -254,7 +254,9 @@ func buildStructIndex(rt reflect.Type) fieldIndex {
 				continue
 			}
 			ft := sf.Type
-			path := append(append([]int(nil), base...), i)
+			path := make([]int, len(base)+1)
+			copy(path, base)
+			path[len(base)] = i
 
 			if inline || (sf.Anonymous && (forceInline || tag == "")) {
 				if isStruct(ft) || (ft.Kind() == reflect.Ptr && isStruct(ft.Elem())) {


### PR DESCRIPTION
Replaces
```go
path := append(append([]int(nil), base...), i)
```
with
```go
path := make([]int, len(base)+1)
copy(path, base)
path[len(base)] = i
```
This change:
   - Avoids the intermediate slice allocation caused by append([]int(nil), base...).
   - Improves performance by directly allocating the final slice size and copying elements once.
   - Maintains the same behavior while being more memory efficient.